### PR TITLE
Release 5.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,10 +31,11 @@
   "minimum-stability": "dev",
   "prefer-stable":     true,
   "require":     {
-    "dreamfactory/df-database": "~0.12",
+    "php":                      "^8.0",
+    "dreamfactory/df-database": "~1.0",
     "dreamfactory/df-email":    "~0.10",
-    "dreamfactory/df-file":     "~0.7",
-    "dreamfactory/df-sqldb":    "~0.17",
+    "dreamfactory/df-file":     "~0.8",
+    "dreamfactory/df-sqldb":    "~1.0",
     "aws/aws-sdk-php":          "3.*"
   },
   "autoload":    {

--- a/src/Resources/SnsApplication.php
+++ b/src/Resources/SnsApplication.php
@@ -6,6 +6,7 @@ use DreamFactory\Core\Exceptions\BadRequestException;
 use DreamFactory\Core\Exceptions\InternalServerErrorException;
 use DreamFactory\Core\Exceptions\NotFoundException;
 use DreamFactory\Core\Contracts\ServiceResponseInterface;
+use Illuminate\Support\Arr;
 
 /**
  * Class SnsApplication
@@ -85,17 +86,17 @@ class SnsApplication extends BaseSnsResource
     {
         parent::setResourceMembers($resourcePath);
 
-        $this->resource = array_get($this->resourceArray, 0);
+        $this->resource = Arr::get($this->resourceArray, 0);
 
         $pos = 1;
-        $more = array_get($this->resourceArray, $pos);
+        $more = Arr::get($this->resourceArray, $pos);
 
         if (!empty($more)) {
             if (SnsEndpoint::RESOURCE_NAME !== $more) {
                 do {
                     $this->resource .= '/' . $more;
                     $pos++;
-                    $more = array_get($this->resourceArray, $pos);
+                    $more = Arr::get($this->resourceArray, $pos);
                 } while (!empty($more) && (SnsEndpoint::RESOURCE_NAME !== $more));
             }
         }
@@ -116,16 +117,16 @@ class SnsApplication extends BaseSnsResource
             switch ($fields) {
                 case false:
                 case Sns::FORMAT_SIMPLE:
-                    $resources[] = $this->service->stripArnPrefix(array_get($app, 'PlatformApplicationArn'));
+                    $resources[] = $this->service->stripArnPrefix(Arr::get($app, 'PlatformApplicationArn'));
                     break;
                 case Sns::FORMAT_ARN:
-                    $resources[] = array_get($app, 'PlatformApplicationArn');
+                    $resources[] = Arr::get($app, 'PlatformApplicationArn');
                     break;
                 case true:
                 case Sns::FORMAT_FULL:
                 default:
                     $app['Application'] =
-                        $this->service->stripArnPrefix(array_get($app, 'PlatformApplicationArn'));
+                        $this->service->stripArnPrefix(Arr::get($app, 'PlatformApplicationArn'));
                     $resources[] = $app;
                     break;
             }
@@ -205,7 +206,7 @@ class SnsApplication extends BaseSnsResource
 
         try {
             if (null !== $result = $this->service->getConnection()->getPlatformApplicationAttributes($request)) {
-                $attributes = array_get($result->toArray(), 'Attributes');
+                $attributes = Arr::get($result->toArray(), 'Attributes');
 
                 return [
                     'Application'            => $this->service->stripArnPrefix($resource),
@@ -228,7 +229,7 @@ class SnsApplication extends BaseSnsResource
     public function createApplication($request)
     {
         if (is_array($request)) {
-            $name = array_get($request, 'Name');
+            $name = Arr::get($request, 'Name');
             if (empty($name)) {
                 throw new BadRequestException("Create application request contains no 'Name' field.");
             }
@@ -238,7 +239,7 @@ class SnsApplication extends BaseSnsResource
 
         try {
             if (null !== $result = $this->service->getConnection()->createPlatformApplication($request)) {
-                $arn = array_get($result->toArray(), 'PlatformApplicationArn', '');
+                $arn = Arr::get($result->toArray(), 'PlatformApplicationArn', '');
 
                 return ['Application' => $this->service->stripArnPrefix($arn), 'PlatformApplicationArn' => $arn];
             }
@@ -257,7 +258,7 @@ class SnsApplication extends BaseSnsResource
     public function updateApplication($request)
     {
         if (is_array($request)) {
-            $name = array_get($request, 'Application', array_get($request, 'PlatformApplicationArn'));
+            $name = Arr::get($request, 'Application', Arr::get($request, 'PlatformApplicationArn'));
             if (empty($name)) {
                 throw new BadRequestException("Update application request contains no 'Application' field.");
             }
@@ -289,7 +290,7 @@ class SnsApplication extends BaseSnsResource
     {
         $data = [];
         if (is_array($request)) {
-            $name = array_get($request, 'Application', array_get($request, 'PlatformApplicationArn'));
+            $name = Arr::get($request, 'Application', Arr::get($request, 'PlatformApplicationArn'));
             if (empty($name)) {
                 throw new BadRequestException("Delete application request contains no 'Application' field.");
             }

--- a/src/Resources/SnsEndpoint.php
+++ b/src/Resources/SnsEndpoint.php
@@ -6,6 +6,7 @@ use DreamFactory\Core\Exceptions\BadRequestException;
 use DreamFactory\Core\Exceptions\InternalServerErrorException;
 use DreamFactory\Core\Exceptions\NotFoundException;
 use DreamFactory\Core\Contracts\ServiceResponseInterface;
+use Illuminate\Support\Arr;
 
 /**
  * Class SnsEndpoint
@@ -93,17 +94,17 @@ class SnsEndpoint extends BaseSnsResource
     {
         parent::setResourceMembers($resourcePath);
 
-        $this->resource = array_get($this->resourceArray, 0);
+        $this->resource = Arr::get($this->resourceArray, 0);
 
         $pos = 1;
-        $more = array_get($this->resourceArray, $pos);
+        $more = Arr::get($this->resourceArray, $pos);
 
         if (!empty($more)) {
             //  This will be the full resource path
             do {
                 $this->resource .= '/' . $more;
                 $pos++;
-                $more = array_get($this->resourceArray, $pos);
+                $more = Arr::get($this->resourceArray, $pos);
             } while (!empty($more));
         }
 
@@ -154,7 +155,7 @@ class SnsEndpoint extends BaseSnsResource
                 } while ($token);
 
                 foreach ($out as $app) {
-                    $applications[] = array_get($app, 'PlatformApplicationArn');
+                    $applications[] = Arr::get($app, 'PlatformApplicationArn');
                 }
             } catch (\Exception $ex) {
                 if (null !== $newEx = Sns::translateException($ex)) {
@@ -174,15 +175,15 @@ class SnsEndpoint extends BaseSnsResource
                 switch ($fields) {
                     case false:
                     case Sns::FORMAT_SIMPLE:
-                        $resources[] = $this->service->stripArnPrefix(array_get($end, 'EndpointArn'));
+                        $resources[] = $this->service->stripArnPrefix(Arr::get($end, 'EndpointArn'));
                         break;
                     case Sns::FORMAT_ARN:
-                        $resources[] = array_get($end, 'EndpointArn');
+                        $resources[] = Arr::get($end, 'EndpointArn');
                         break;
                     case true:
                     case Sns::FORMAT_FULL:
                     default:
-                        $end['Endpoint'] = $this->service->stripArnPrefix(array_get($end, 'EndpointArn'));
+                        $end['Endpoint'] = $this->service->stripArnPrefix(Arr::get($end, 'EndpointArn'));
                         $resources[] = $end;
                         break;
                 }
@@ -268,7 +269,7 @@ class SnsEndpoint extends BaseSnsResource
 
         try {
             if (null !== $result = $this->service->getConnection()->getEndpointAttributes($request)) {
-                $attributes = array_get($result->toArray(), 'Attributes');
+                $attributes = Arr::get($result->toArray(), 'Attributes');
 
                 return [
                     'Endpoint'    => $this->service->stripArnPrefix($resource),
@@ -298,12 +299,12 @@ class SnsEndpoint extends BaseSnsResource
     public function createEndpoint($request)
     {
         if (is_array($request)) {
-            $name = array_get($request, 'Application', array_get($request, 'PlatformApplicationArn'));
+            $name = Arr::get($request, 'Application', Arr::get($request, 'PlatformApplicationArn'));
             if (empty($name)) {
                 throw new BadRequestException("Create endpoint request contains no 'Application' field.");
             }
             $request['PlatformApplicationArn'] = $this->service->addArnPrefix($name);
-            $name = array_get($request, 'Token');
+            $name = Arr::get($request, 'Token');
             if (empty($name)) {
                 throw new BadRequestException("Create endpoint request contains no 'Token' field.");
             }
@@ -313,7 +314,7 @@ class SnsEndpoint extends BaseSnsResource
 
         try {
             if (null !== $result = $this->service->getConnection()->createPlatformEndpoint($request)) {
-                $arn = array_get($result->toArray(), 'EndpointArn', '');
+                $arn = Arr::get($result->toArray(), 'EndpointArn', '');
 
                 return ['Endpoint' => $this->service->stripArnPrefix($arn), 'EndpointArn' => $arn];
             }
@@ -341,7 +342,7 @@ class SnsEndpoint extends BaseSnsResource
     public function updateEndpoint($request)
     {
         if (is_array($request)) {
-            $name = array_get($request, 'Endpoint', array_get($request, 'EndpointArn'));
+            $name = Arr::get($request, 'Endpoint', Arr::get($request, 'EndpointArn'));
             if (empty($name)) {
                 throw new BadRequestException("Update endpoint request contains no 'Endpoint' field.");
             }
@@ -378,7 +379,7 @@ class SnsEndpoint extends BaseSnsResource
     {
         $data = [];
         if (is_array($request)) {
-            $name = array_get($request, 'Endpoint', array_get($request, 'EndpointArn'));
+            $name = Arr::get($request, 'Endpoint', Arr::get($request, 'EndpointArn'));
             if (empty($name)) {
                 throw new BadRequestException("Delete endpoint request contains no 'Endpoint' field.");
             }

--- a/src/Resources/SnsSubscription.php
+++ b/src/Resources/SnsSubscription.php
@@ -6,6 +6,7 @@ use DreamFactory\Core\Exceptions\BadRequestException;
 use DreamFactory\Core\Exceptions\InternalServerErrorException;
 use DreamFactory\Core\Exceptions\NotFoundException;
 use DreamFactory\Core\Contracts\ServiceResponseInterface;
+use Illuminate\Support\Arr;
 
 /**
  * Class SnsSubscription
@@ -96,15 +97,15 @@ class SnsSubscription extends BaseSnsResource
             switch ($fields) {
                 case false:
                 case Sns::FORMAT_SIMPLE:
-                    $resources[] = $this->service->stripArnPrefix(array_get($sub, 'SubscriptionArn'));
+                    $resources[] = $this->service->stripArnPrefix(Arr::get($sub, 'SubscriptionArn'));
                     break;
                 case Sns::FORMAT_ARN:
-                    $resources[] = array_get($sub, 'SubscriptionArn');
+                    $resources[] = Arr::get($sub, 'SubscriptionArn');
                     break;
                 case true:
                 case Sns::FORMAT_FULL:
                 default:
-                    $sub['Subscription'] = $this->service->stripArnPrefix(array_get($sub, 'SubscriptionArn'));
+                    $sub['Subscription'] = $this->service->stripArnPrefix(Arr::get($sub, 'SubscriptionArn'));
                     $resources[] = $sub;
                     break;
             }
@@ -188,7 +189,7 @@ class SnsSubscription extends BaseSnsResource
 
         try {
             if (null !== $result = $this->service->getConnection()->getSubscriptionAttributes($request)) {
-                $out = array_merge($request, array_get($result->toArray(), 'Attributes', []));
+                $out = array_merge($request, Arr::get($result->toArray(), 'Attributes', []));
                 $out['Subscription'] = $this->service->stripArnPrefix($resource);
 
                 return $out;
@@ -208,7 +209,7 @@ class SnsSubscription extends BaseSnsResource
     public function createSubscription($request)
     {
         if (is_array($request)) {
-            $name = array_get($request, 'Topic', array_get($request, 'TopicArn'));
+            $name = Arr::get($request, 'Topic', Arr::get($request, 'TopicArn'));
             if (empty($name)) {
                 throw new BadRequestException("Create Subscription request contains no 'Topic' field.");
             }
@@ -220,7 +221,7 @@ class SnsSubscription extends BaseSnsResource
 
         try {
             if (null !== $result = $this->service->getConnection()->subscribe($request)) {
-                $arn = array_get($result->toArray(), 'SubscriptionArn', '');
+                $arn = Arr::get($result->toArray(), 'SubscriptionArn', '');
 
                 return ['Subscription' => $this->service->stripArnPrefix($arn), 'SubscriptionArn' => $arn];
             }
@@ -239,7 +240,7 @@ class SnsSubscription extends BaseSnsResource
     public function updateSubscription($request)
     {
         if (is_array($request)) {
-            $name = array_get($request, 'Subscription', array_get($request, 'SubscriptionArn'));
+            $name = Arr::get($request, 'Subscription', Arr::get($request, 'SubscriptionArn'));
             if (empty($name)) {
                 throw new BadRequestException("Update subscription request contains no 'Subscription' field.");
             }
@@ -269,7 +270,7 @@ class SnsSubscription extends BaseSnsResource
     {
         $data = [];
         if (is_array($request)) {
-            $name = array_get($request, 'Subscription', array_get($request, 'SubscriptionArn'));
+            $name = Arr::get($request, 'Subscription', Arr::get($request, 'SubscriptionArn'));
             if (empty($name)) {
                 throw new BadRequestException("Delete subscription request contains no 'Subscription' field.");
             }

--- a/src/Resources/SnsTopic.php
+++ b/src/Resources/SnsTopic.php
@@ -6,6 +6,7 @@ use DreamFactory\Core\Exceptions\BadRequestException;
 use DreamFactory\Core\Exceptions\InternalServerErrorException;
 use DreamFactory\Core\Exceptions\NotFoundException;
 use DreamFactory\Core\Contracts\ServiceResponseInterface;
+use Illuminate\Support\Arr;
 
 /**
  * Class SnsTopic
@@ -86,15 +87,15 @@ class SnsTopic extends BaseSnsResource
             switch ($fields) {
                 case false:
                 case Sns::FORMAT_SIMPLE:
-                    $resources[] = $this->service->stripArnPrefix(array_get($topic, 'TopicArn'));
+                    $resources[] = $this->service->stripArnPrefix(Arr::get($topic, 'TopicArn'));
                     break;
                 case Sns::FORMAT_ARN:
-                    $resources[] = array_get($topic, 'TopicArn');
+                    $resources[] = Arr::get($topic, 'TopicArn');
                     break;
                 case true:
                 case Sns::FORMAT_FULL:
                 default:
-                    $topic['Topic'] = $this->service->stripArnPrefix(array_get($topic, 'TopicArn'));
+                    $topic['Topic'] = $this->service->stripArnPrefix(Arr::get($topic, 'TopicArn'));
                     $resources[] = $topic;
                     break;
             }
@@ -174,7 +175,7 @@ class SnsTopic extends BaseSnsResource
 
         try {
             if (null !== $result = $this->service->getConnection()->getTopicAttributes($request)) {
-                $out = array_get($result->toArray(), 'Attributes');
+                $out = Arr::get($result->toArray(), 'Attributes');
                 $out['Topic'] = $this->service->stripArnPrefix($resource);
 
                 return $out;
@@ -195,7 +196,7 @@ class SnsTopic extends BaseSnsResource
     {
         $data = [];
         if (is_array($request)) {
-            $name = array_get($request, 'Name');
+            $name = Arr::get($request, 'Name');
             if (empty($name)) {
                 throw new BadRequestException("Create Topic request contains no 'Name' field.");
             }
@@ -207,7 +208,7 @@ class SnsTopic extends BaseSnsResource
 
         try {
             if (null !== $result = $this->service->getConnection()->createTopic($data)) {
-                $arn = array_get($result->toArray(), 'TopicArn', '');
+                $arn = Arr::get($result->toArray(), 'TopicArn', '');
 
                 return ['Topic' => $this->service->stripArnPrefix($arn), 'TopicArn' => $arn];
             }
@@ -226,7 +227,7 @@ class SnsTopic extends BaseSnsResource
     public function updateTopic($request)
     {
         if (is_array($request)) {
-            $name = array_get($request, 'Topic', array_get($request, 'TopicArn'));
+            $name = Arr::get($request, 'Topic', Arr::get($request, 'TopicArn'));
             if (empty($name)) {
                 throw new BadRequestException("Update topic request contains no 'Topic' field.");
             }
@@ -256,7 +257,7 @@ class SnsTopic extends BaseSnsResource
     {
         $data = [];
         if (is_array($request)) {
-            $name = array_get($request, 'Topic', array_get($request, 'TopicArn'));
+            $name = Arr::get($request, 'Topic', Arr::get($request, 'TopicArn'));
             if (empty($name)) {
                 throw new BadRequestException("Delete Topic request contains no 'Topic' field.");
             }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -98,7 +98,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         });
 
         // Add our database extensions.
-        $this->app->resolving('db.schema', function (DbSchemaExtensions $db) {
+        $this->app->resolving('df.db.schema', function (DbSchemaExtensions $db) {
             $db->extend('redshift', function ($connection) {
                 return new RedshiftSchema($connection);
             });

--- a/src/Services/DynamoDb.php
+++ b/src/Services/DynamoDb.php
@@ -7,6 +7,7 @@ use DreamFactory\Core\Aws\Database\Schema\DynamoDbSchema;
 use DreamFactory\Core\Aws\Resources\DynamoDbTable;
 use DreamFactory\Core\Database\Services\BaseDbService;
 use DreamFactory\Core\Exceptions\InternalServerErrorException;
+use Illuminate\Support\Arr;
 
 /**
  * DynamoDb
@@ -37,13 +38,13 @@ class DynamoDb extends BaseDbService
         }
 
         // set up a default table schema
-//        $parameters = (array)array_get($this->config, 'parameters');
-//        if (null !== ($table = array_get($parameters, 'default_create_table'))) {
+//        $parameters = (array)Arr::get($this->config, 'parameters');
+//        if (null !== ($table = Arr::get($parameters, 'default_create_table'))) {
 //            $this->defaultCreateTable = $table;
 //        }
 
-        $this->setConfigBasedCachePrefix(array_get($this->config, 'credentials.key') .
-            array_get($this->config, 'region') . ':');
+        $this->setConfigBasedCachePrefix(Arr::get($this->config, 'credentials.key') .
+            Arr::get($this->config, 'region') . ':');
     }
 
     public function getResourceHandlers()

--- a/src/Services/S3.php
+++ b/src/Services/S3.php
@@ -4,6 +4,7 @@ namespace DreamFactory\Core\Aws\Services;
 use DreamFactory\Core\Aws\Components\S3FileSystem;
 use DreamFactory\Core\Exceptions\InternalServerErrorException;
 use DreamFactory\Core\File\Services\RemoteFileService;
+use Illuminate\Support\Arr;
 
 /**
  * Class S3
@@ -17,7 +18,7 @@ class S3 extends RemoteFileService
      */
     protected function setDriver($config)
     {
-        $this->container = array_get($config, 'container');
+        $this->container = Arr::get($config, 'container');
 
         if (empty($this->container)) {
             throw new InternalServerErrorException('S3 file service bucket not specified. Please check configuration for file service - ' .

--- a/src/Services/Ses.php
+++ b/src/Services/Ses.php
@@ -14,9 +14,9 @@ class Ses extends BaseService
      */
     protected function setTransport($config)
     {
-        $key = array_get($config, 'key');
-        $secret = array_get($config, 'secret');
-        $region = array_get($config, 'region', 'us-east-1');
+        $key = Arr::get($config, 'key');
+        $secret = Arr::get($config, 'secret');
+        $region = Arr::get($config, 'region', 'us-east-1');
 
         $this->transport = static::getTransport($key, $secret, $region);
     }


### PR DESCRIPTION
 - Update dependencies
 - Get rid of global helper functions
 - Handle empty argument in array_merge
 - Fix exception error to suit to integration test
 - Refactor blob streaming in order to support file caching added in df-file v0.8 (see RemoteFileSystem::streamBlobIfModified). Vendor details implemented in S3FileSystem::getBlobInChunks
 - Resolve conflict with db.schema component

 App code used `db.schema` name for `DbSchemaExtensions` component.
 Starting from Laravel 9 this name is used internally
 because of migration to string based accessor for Schema facade
 laravel/framework@8059b39.
 The cure is to use `df` prefix for app `db.schema` component.